### PR TITLE
windows support (testing)

### DIFF
--- a/test_git_fetch_file.py
+++ b/test_git_fetch_file.py
@@ -35,8 +35,8 @@ class TestGitRepository(unittest.TestCase):
         subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
         os.chdir(self.oldpwd)
+        shutil.rmtree(self.tmpdir)
 
 
 class TestAdd(TestGitRepository):


### PR DESCRIPTION
just a few small tweaks to be able to run the tests on windows (while being configured for using git-bash.exe)

makes
```
git clone https://github.com/andrewmcwattersandco/git-fetch-file.git
git config --global alias.fetch-file '!py '"$(realpath git-fetch-file/git-fetch-file.py)"
```
act correctly

also results in a nice
```
C:\Python\Python313\python.exe "C:/Program Files/JetBrains/PyCharm 2025.2.0.1/plugins/python-ce/helpers/pycharm/_jb_unittest_runner.py" --path C:\dev\git-fetch-file\test_git_fetch_file.py 
Testing started at X:YZ PM ...
Launching unittests with arguments python -m unittest C:\dev\git-fetch-file\test_git_fetch_file.py in C:\dev\git-fetch-file

Initialized empty Git repository in C:/Users/Administrator/AppData/Local/Temp/1/tmp7hmj7256/.git/
Added file README from https://github.com/octocat/Hello-World.git (On branch master at 7fd1a60)
Initialized empty Git repository in C:/Users/Administrator/AppData/Local/Temp/1/tmpsmhasrok/.git/
Added file README from https://github.com/octocat/Hello-World.git (On branch master at 7fd1a60)
Fetched README -> README at 7fd1a60b01f91b314f59955a4e4d4e80d8edf11d


Ran 3 tests in 3.129s

OK

Process finished with exit code 0
```


And while the `script_path "[1]+':'+[2:]"` drive-letter hack is not the cleanest, it should work for everything it may encounter 
(and saves on an extra subshell to call cygpath :D )